### PR TITLE
Add INT-based damage perk calculations

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,6 +489,9 @@ h1 {
   <label class="output2" for="baseXp">Base XP:</label>
   <input class="output2" type="number" id="baseXp" value="100" style="width: 80px; text-align: right;">
   <p class="output2" id="xpTestResult">Total XP: 0</p>
+  <p class="output2" id="scienceBonus">Science!: +0% Energy Dmg</p>
+  <p class="output2" id="pyroBonus">Pyro-Technician: +0% Fire Dmg</p>
+  <p class="output2" id="cryoBonus">Cryologist: +0% Cryo Dmg</p>
 </fieldset>
 <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -91,6 +91,19 @@ document.addEventListener('DOMContentLoaded', () => {
     display.textContent = `+${bonus.int} INT +${bonus.chr} CHR`;
   }
 
+  function getIntDamageBonus(intVal) {
+    if (intVal <= 15) {
+      return (17 / 14) * intVal + (53 / 14);
+    } else if (intVal <= 30) {
+      return (13 / 15) * intVal + 9;
+    } else if (intVal <= 60) {
+      return (1 / 3) * intVal + 25;
+    } else if (intVal <= 100) {
+      return (1 / 8) * intVal + 37.5;
+    }
+    return 50;
+  }
+
   function calculate() {
     const baseInt = getVal('baseInt');
     const legendInt = getVal('legendInt');
@@ -385,7 +398,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const lines = [];
 
       // Header
-      lines.push('Formula :');
+      lines.push('Formula:');
 
       // INT multiplier
       const intMultiplier = 1 + (totalInt * 0.03);
@@ -422,6 +435,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const baseXp = parseFloat(document.getElementById('baseXp').value) || 0;
       const finalXp = baseXp * totalMultiplier;
       document.getElementById('xpTestResult').textContent = 'Total XP: ' + Math.round(finalXp);
+
+      const dmgBonus = getIntDamageBonus(totalInt);
+      document.getElementById('scienceBonus').textContent = `Science!: +${dmgBonus.toFixed(2)}% Energy Dmg`;
+      document.getElementById('pyroBonus').textContent = `Pyro-Technician: +${dmgBonus.toFixed(2)}% Fire Dmg`;
+      document.getElementById('cryoBonus').textContent = `Cryologist: +${dmgBonus.toFixed(2)}% Cryo Dmg`;
     }
 
     updateCalculations(totalInt, totalXp, bedBonus, lunchboxBonus, teamXpBonus);


### PR DESCRIPTION
## Summary
- adjust formatting of calculation formula header
- compute damage bonus based on INT for Science!, Pyro-Technician and Cryologist perks
- display new perk bonuses in the Calculations section

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684843de3fc88326a5d5306fb85fc507