### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,87 @@ h1 {
     font-size: 0.85em;
     color: #444; /* optional for slightly muted tone */
 }
+
+/* Dark mode styles */
+body.dark-mode {
+    color: white;
+}
+
+body.dark-mode fieldset {
+    background: #000;
+    color: white;
+    border-color: #fff;
+}
+
+body.dark-mode table td {
+    border-color: #fff;
+}
+
+body.dark-mode input,
+body.dark-mode select {
+    background: #333;
+    color: white;
+    border: 1px solid #555;
+}
+
+/* Dark mode toggle switch */
+#darkModeContainer {
+    position: fixed;
+    bottom: 10px;
+    left: 10px;
+    z-index: 1000;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 50px;
+    height: 24px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: .4s;
+}
+
+input:checked + .slider {
+    background-color: #2196F3;
+}
+
+input:checked + .slider:before {
+    transform: translateX(26px);
+}
+
+.slider.round {
+    border-radius: 24px;
+}
+
+.slider.round:before {
+    border-radius: 50%;
+}
 #calculationTable {
     text-align: center;
     border: 1px solid #000;
@@ -523,6 +604,12 @@ h1 {
     </tr>
   </table>
 </fieldset>
+<div id="darkModeContainer">
+  <label class="switch">
+    <input type="checkbox" id="darkModeToggle">
+    <span class="slider round"></span>
+  </label>
+</div>
 <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -544,4 +544,13 @@ document.addEventListener('DOMContentLoaded', () => {
   updateInternalDataState();
 
   calculate();
+
+  const darkToggle = document.getElementById('darkModeToggle');
+  darkToggle.addEventListener('change', () => {
+    if (darkToggle.checked) {
+      document.body.classList.add('dark-mode');
+    } else {
+      document.body.classList.remove('dark-mode');
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- implement a fixed dark mode toggle in the bottom left corner
- add dark mode styles to switch text to white and boxes to black
- handle toggle state with JS

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684ec4e0986c83268e5f197df878ac2b