### PR TITLE
Add sharable state via URL parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -604,6 +604,10 @@ input:checked + .slider:before {
     </tr>
   </table>
 </fieldset>
+<div id="shareContainer" style="margin-top:10px;">
+  <button id="shareButton">Copy Share Link</button>
+  <span id="shareStatus"></span>
+</div>
 <div id="darkModeContainer">
   <label class="switch">
     <input type="checkbox" id="darkModeToggle">

--- a/script.js
+++ b/script.js
@@ -449,8 +449,50 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     updateCalculations(totalInt, totalXp, bedBonus, lunchboxBonus, teamXpBonus);
+
+    saveState();
   }
 
+  function createQueryParams() {
+    const params = new URLSearchParams();
+    document.querySelectorAll("input, select").forEach(el => {
+      if (el.type === "radio") {
+        if (el.checked) params.set(el.name, el.value);
+      } else if (el.id) {
+        if (el.type === "checkbox") params.set(el.id, el.checked ? "1" : "0");
+        else params.set(el.id, el.value);
+      }
+    });
+    return params;
+  }
+
+  function saveState() {
+    const params = createQueryParams();
+    const query = params.toString();
+    localStorage.setItem("xpCalcState", query);
+    const url = window.location.pathname + "?" + query;
+    history.replaceState(null, "", url);
+    return window.location.origin + url;
+  }
+
+  function loadState() {
+    const query = window.location.search.substring(1) || localStorage.getItem("xpCalcState");
+    if (!query) return;
+    const params = new URLSearchParams(query);
+    params.forEach((value, key) => {
+      const el = document.getElementById(key);
+      if (el) {
+        if (el.type === "checkbox") {
+          el.checked = value === "1";
+        } else {
+          el.value = value;
+        }
+      } else {
+        const radios = document.querySelectorAll(`input[name="${key}"]`);
+        radios.forEach(r => { if (r.value === value) r.checked = true; });
+      }
+    });
+  }
   // Event Listeners
   document.getElementById('hpTier').addEventListener('change', calculate);
   document.querySelectorAll('input[type="checkbox"]').forEach(el => el.addEventListener('change', calculate));
@@ -541,16 +583,30 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // Initialize on page load
+  loadState();
+  updateUnderArmorBonusDisplay();
   updateInternalDataState();
-
   calculate();
 
-  const darkToggle = document.getElementById('darkModeToggle');
-  darkToggle.addEventListener('change', () => {
+  const darkToggle = document.getElementById("darkModeToggle");
+  darkToggle.addEventListener("change", () => {
     if (darkToggle.checked) {
-      document.body.classList.add('dark-mode');
+      document.body.classList.add("dark-mode");
     } else {
-      document.body.classList.remove('dark-mode');
+      document.body.classList.remove("dark-mode");
     }
   });
+
+  const shareButton = document.getElementById("shareButton");
+  const shareStatus = document.getElementById("shareStatus");
+  if (shareButton) {
+    shareButton.addEventListener("click", () => {
+      const url = saveState();
+      navigator.clipboard.writeText(url).then(() => {
+        shareStatus.textContent = "Link copied!";
+      }).catch(() => {
+        shareStatus.textContent = "Copy failed";
+      });
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- add a Share button below the calculator that copies a link
- track all inputs in the URL and `localStorage`
- restore saved state on load

## Testing
- `node -e "require('./script.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6850285da03c8326a2c5aaa0828430e5