### PR TITLE
Fix table border in dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,11 @@ body.dark-mode table td {
     border-color: #fff;
 }
 
+body.dark-mode #calculationTable,
+body.dark-mode #calculationTable td {
+    border-color: #fff;
+}
+
 body.dark-mode input,
 body.dark-mode select {
     background: #333;


### PR DESCRIPTION
## Summary
- ensure the Science/Pyro/Cryo table lines show white borders in dark mode

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851a820e7548326b917f1607495b9a9