### PR TITLE
Show video button when preset sliders selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,16 @@ body.dark-mode select {
     z-index: 1000;
 }
 
+#videoButton {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1000;
+    width: 240px;
+    display: none;
+}
+
 .switch {
     position: relative;
     display: inline-block;
@@ -625,6 +635,9 @@ input:checked + .slider:before {
     <span class="slider round"></span>
   </label>
 </div>
+<a href="https://youtu.be/aF5PUiR7EZs?si=MTWYoBdpNVXJ9R9_&t=29" target="_blank">
+  <img src="Fo76.png" id="videoButton" alt="Video">
+</a>
 <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -14,11 +14,23 @@ document.addEventListener('DOMContentLoaded', () => {
         display.textContent = val;
       }
       calculate();
+      updateVideoButton();
     };
     slider.addEventListener('input', update);
     update();
   }
 
+
+  const videoButton = $('videoButton');
+
+  function updateVideoButton() {
+    const show =
+      getVal('baseInt') === 2 &&
+      getVal('legendInt') === 3 &&
+      getVal('baseCha') === 4 &&
+      getVal('legendCha') === 5;
+    videoButton.style.display = show ? 'block' : 'none';
+  }
 
   bindSlider('baseInt', 'baseIntVal');
   bindSlider('legendInt', 'legendIntVal');
@@ -553,6 +565,7 @@ document.addEventListener('DOMContentLoaded', () => {
   updateInternalDataState();
 
   calculate();
+  updateVideoButton();
 
   const darkToggle = $('darkModeToggle');
   darkToggle.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- hide video button by default
- show button only when INT 2, Legendary INT 3, CHA 4, and Legendary CHA 5 are chosen
- keep default slider values at 1/0 instead of preset values
- make video button four times larger

## Testing
- `npm test` *(fails: could not find `package.json`)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852cd14ec0c8326b493cbb56a5de6d9